### PR TITLE
chore: use PROJECT_SOURCE instead of PROJECTS_ROOT

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -2,9 +2,9 @@ schemaVersion: 2.1.0
 metadata:
   name: nodejs-web-app
 components:
-  - name: nodejs
+  - name: tools
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-b452131
+      image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
       endpoints:
         - exposure: public
           name: nodejs
@@ -12,37 +12,41 @@ components:
           targetPort: 3000
       memoryLimit: 1G
       mountSources: true
+
 commands:
-  - id: dependencies
+  - id: install-dependencies
     exec:
-      label: "Download dependencies"
-      component: nodejs
-      workingDir: ${PROJECTS_ROOT}/web-nodejs-sample/app
+      label: "Install dependencies"
+      component: tools
+      workingDir: ${PROJECT_SOURCE}/app
       commandLine: "npm install"
       group:
         kind: build
         isDefault: true
-  - id: runapp
+
+  - id: run-application
     exec:
-      label: "Run the web app"
-      component: nodejs
-      workingDir: ${PROJECTS_ROOT}/web-nodejs-sample/app
+      label: "Run web application"
+      component: tools
+      workingDir: ${PROJECT_SOURCE}/app
       commandLine: "nodemon app.js"
       group:
         kind: run
+
   - id: debug
     exec:
-      label: "Run the web app (debugging enabled)"
-      component: nodejs
-      workingDir: ${PROJECTS_ROOT}/web-nodejs-sample/app
+      label: "Run web application (debugging enabled)"
+      component: tools
+      workingDir: ${PROJECT_SOURCE}/app
       commandLine: "nodemon --inspect app.js"
       group:
         kind: debug
         isDefault: true
-  - id: stopapp
+
+  - id: stop-application
     exec:
-      label: "Stop the web app"
-      component: nodejs
+      label: "Stop web application"
+      component: tools
       commandLine: >-
           node_server_pids=$(pgrep -fx '.*nodemon (--inspect )?app.js' | tr "\\n" " ") &&
           echo "Stopping node server with PIDs: ${node_server_pids}" && 


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

- Replaces PROJECTS_ROOT environment variable on PROJECT_SOURCE in devfile commands
- Bumps to the latest tag of universal developer image
