### PR TITLE
chore: use https protocol in endpoint

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -8,7 +8,7 @@ components:
       endpoints:
         - exposure: public
           name: nodejs
-          protocol: http
+          protocol: https
           targetPort: 3000
       memoryLimit: 1G
       mountSources: true


### PR DESCRIPTION
chore: use https protocol in endpoint

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2023 12 21-12_39_59](https://github.com/che-samples/web-nodejs-sample/assets/1271546/71baf1b2-36be-4305-882a-8feb633f2ebc)


Related issue: https://issues.redhat.com/browse/CRW-5377