### PR TITLE
set devfile schemVersion 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: nodejs-web-app
 components:


### PR DESCRIPTION
Set devfile schemaVersion: 2.2.2

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2024 01 31-15_56_02](https://github.com/che-samples/web-nodejs-sample/assets/1271546/fcd28c9b-a6fa-4326-bcb6-5c54c00d8d89)

Related issue: https://github.com/eclipse/che/issues/21985

